### PR TITLE
Add schema-registry-kafkaconnect-converter dependency

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -170,6 +170,11 @@
             <version>3.20.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.glue</groupId>
+            <artifactId>schema-registry-kafkaconnect-converter</artifactId>
+            <version>1.1.12</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
### Context

In order for a kafka connect consumer to process records serialized using AWS glue schema registry managed schemas we need to ensure that an instance of `AWSKafkaAvroConverter` with the changes detailed [here](https://github.com/awslabs/aws-glue-schema-registry/pull/209), is available on the classpath.

### Changes

The following steps were used to build a zip file that can be deployed to MSK connect.

#### Build, and publish to local maven repo, package containing `AWSKafkaAvroConverter` with changes

```
git clone git@github.com:awslabs/aws-glue-schema-registry.git
cd aws-glue-schema-registry
git fetch origin pull/209/head:209
git checkout 209
mvn clean install
mvn install:install-file \
   -Dfile=./avro-kafkaconnect-converter/target/schema-registry-kafkaconnect-converter-1.1.12.jar \
   -DgroupId=software.amazon.glue \
   -DartifactId=schema-registry-kafkaconnect-converter \
   -Dversion=1.1.12 \
   -Dpackaging=jar \
   -DgeneratePom=true
```

#### Build zip for deployment to MSK connect

https://github.com/privacy-com/kafka-connect-storage-cloud/releases/tag/v10.0.10-aws-glue-schema-registry

```
git clone git@github.com:privacy-com/kafka-connect-storage-cloud.git
cd kafka-connect-storage-cloud
git fetch origin pull/1/head:1
git checkout 1
mvn clean install -DskipTests
cp kafka-connect-s3/target/components/packages/confluentinc-kafka-connect-s3-10.0.10.zip ~/msk-connectors/confluentinc-kafka-connect-s3-10.0.10-aws-glue-schema-registry.zip
```
